### PR TITLE
fix: List item cell max width has been removed, Chat History panel width and infinite scroll on scroll only

### DIFF
--- a/code/frontend/src/pages/chat/Chat.module.css
+++ b/code/frontend/src/pages/chat/Chat.module.css
@@ -9,6 +9,9 @@
     width: 20vw;
     background: radial-gradient(108.78% 108.78% at 50.02% 19.78%, #FFFFFF 57.29%, #EEF6FE 100%);
     border-radius: 8px;
+    max-height: calc(100vh - 88px);
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.14), 0px 0px 2px rgba(0, 0, 0, 0.12);
+    overflow-y: hidden;
 }
 .chatRoot {
     flex: 1;
@@ -20,6 +23,9 @@
     gap: 20px;
 }
 
+.chatHistoryListContainer {
+    height: 100%;
+}
 .chatContainer {
     flex: 1;
     display: flex;

--- a/code/frontend/src/pages/chat/Chat.tsx
+++ b/code/frontend/src/pages/chat/Chat.tsx
@@ -856,9 +856,7 @@ const Chat = () => {
                 aria-label="chat history panel content"
                 style={{
                   display: "flex",
-                  flexGrow: 1,
-                  flexDirection: "column",
-                  flexWrap: "wrap",
+                  height: '100%',
                   padding: "1px",
                 }}
               >

--- a/code/frontend/src/pages/chat/ChatHistoryListItem.tsx
+++ b/code/frontend/src/pages/chat/ChatHistoryListItem.tsx
@@ -344,7 +344,6 @@ export const ChatHistoryListItemGroups: React.FC<
   toggleToggleSpinner,
 }) => {
   const observerTarget = useRef(null);
-  const [observerCounter, setObserverCounter] = useState(0);
   const handleSelectHistory = (item?: Conversation) => {
     if (typeof item === "object") {
       onSelectConversation(item?.id);
@@ -366,23 +365,11 @@ export const ChatHistoryListItemGroups: React.FC<
     );
   };
 
-  function hasVerticalScrollbar(element: any) {
-    return element?.scrollHeight > element?.clientHeight;
-  }
-
-  useEffect(() => {
-    const element = document.getElementById("historyListContainer");
-    const scrollBar = hasVerticalScrollbar(element);
-    if (element && scrollBar) {
-      handleFetchHistory();
-    }
-  }, [observerCounter]);
-
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0].isIntersecting) {
-          setObserverCounter((observerCounter) => (observerCounter += 1));
+          handleFetchHistory();
         }
       },
       { threshold: 1 }
@@ -453,6 +440,8 @@ export const ChatHistoryListItemGroups: React.FC<
         styles={{
           root: {
             width: "100%",
+            padding: "0px",
+            height: "2px",
             position: "relative",
             "::before": {
               backgroundColor: "#d6d6d6",

--- a/code/frontend/src/pages/chat/ChatHistoryPanel.module.css
+++ b/code/frontend/src/pages/chat/ChatHistoryPanel.module.css
@@ -4,8 +4,9 @@
 }
 
 .listContainer {
+  height: 100%;
   overflow: hidden auto;
-  max-height: calc(90vh - 56px);
+  max-height: 80vh;
 }
 
 .itemCell {

--- a/code/frontend/src/pages/chat/ChatHistoryPanel.module.css
+++ b/code/frontend/src/pages/chat/ChatHistoryPanel.module.css
@@ -10,11 +10,10 @@
 }
 
 .itemCell {
-  max-width: 270px;
   min-height: 32px;
   cursor: pointer;
-  padding-left: 15px;
-  padding-right: 5px;
+  padding-left: 12px;
+  padding-right: 12px;
   padding-top: 5px;
   padding-bottom: 5px;
   box-sizing: border-box;


### PR DESCRIPTION

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

In smaller width of chat history panel conversation option does not overflowing now.
![image](https://github.com/user-attachments/assets/dac82c5f-d82f-4ec6-a5e7-40750880c3c0)

In large screen width of chat history panel conversation option now auto adjusting to width of container.
![image](https://github.com/user-attachments/assets/f13fdf53-baef-47de-8c99-a871ca0cd816)

