### PR TITLE
feat: Add enable chat history to the configuration template

### DIFF
--- a/code/backend/batch/utilities/helpers/config/config_helper.py
+++ b/code/backend/batch/utilities/helpers/config/config_helper.py
@@ -57,7 +57,7 @@ class Config:
             if self.env_helper.AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION
             else None
         )
-        self.enable_chat_history = config["enable_chat_history"]
+        self.enable_chat_history = self.env_helper.CHAT_HISTORY_ENABLED
 
     def get_available_document_types(self) -> list[str]:
         document_types = {
@@ -251,7 +251,8 @@ class ConfigHelper:
                 logger.info("Loading default config from %s", config_file_path)
                 ConfigHelper._default_config = json.loads(
                     Template(f.read()).substitute(
-                        ORCHESTRATION_STRATEGY=env_helper.ORCHESTRATION_STRATEGY
+                        ORCHESTRATION_STRATEGY=env_helper.ORCHESTRATION_STRATEGY,
+                        CHAT_HISTORY_ENABLED=env_helper.CHAT_HISTORY_ENABLED,
                     )
                 )
                 if env_helper.USE_ADVANCED_IMAGE_PROCESSING:

--- a/code/backend/batch/utilities/helpers/config/default.json
+++ b/code/backend/batch/utilities/helpers/config/default.json
@@ -142,5 +142,5 @@
   "orchestrator": {
     "strategy": "${ORCHESTRATION_STRATEGY}"
   },
-  "enable_chat_history": true
+  "enable_chat_history": "${CHAT_HISTORY_ENABLED}"
 }

--- a/code/backend/batch/utilities/helpers/env_helper.py
+++ b/code/backend/batch/utilities/helpers/env_helper.py
@@ -88,7 +88,7 @@ class EnvHelper:
         )
 
         print(os.getenv("AZURE_AUTH_TYPE"))
-        self.AZURE_AUTH_TYPE =  os.getenv("AZURE_AUTH_TYPE", "keys")
+        self.AZURE_AUTH_TYPE = os.getenv("AZURE_AUTH_TYPE", "keys")
         print(f"AZURE_AUTH_TYPE: {self.AZURE_AUTH_TYPE}")
         # Azure OpenAI
         self.AZURE_OPENAI_RESOURCE = os.getenv("AZURE_OPENAI_RESOURCE", "")
@@ -252,6 +252,9 @@ class EnvHelper:
         )
         self.AZURE_COSMOSDB_ENABLE_FEEDBACK = (
             os.getenv("AZURE_COSMOSDB_ENABLE_FEEDBACK", "false").lower() == "true"
+        )
+        self.CHAT_HISTORY_ENABLED = self.get_env_var_bool(
+            "CHAT_HISTORY_ENABLED", "true"
         )
 
     def should_use_data(self) -> bool:

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -10,7 +10,6 @@ param resourceToken string = toLower(uniqueString(subscription().id, environment
 @description('Location for all resources.')
 param location string
 
-
 @description('Name of App Service plan')
 param hostingPlanName string = 'hosting-plan-${resourceToken}'
 
@@ -301,6 +300,13 @@ param recognizedLanguages string = 'en-US,fr-FR,de-DE,it-IT'
 
 @description('Azure Machine Learning Name')
 param azureMachineLearningName string = 'aml-${resourceToken}'
+
+@description('Whether or not to enable chat history')
+@allowed([
+  'true'
+  'false'
+])
+param chatHistoryEnabled string = 'true'
 
 var blobContainerName = 'documents'
 var queueName = 'doc-processing'
@@ -608,7 +614,7 @@ module web './app/web.bicep' = if (hostingModel == 'code') {
       AZURE_COSMOSDB_DATABASE: cosmosDBModule.outputs.cosmosOutput.cosmosDatabaseName
       AZURE_COSMOSDB_CONVERSATIONS_CONTAINER: cosmosDBModule.outputs.cosmosOutput.cosmosContainerName
       AZURE_COSMOSDB_ENABLE_FEEDBACK: true
-      CHAT_HISTORY_ENABLED: true
+      CHAT_HISTORY_ENABLED: chatHistoryEnabled
     }
   }
 }
@@ -696,7 +702,7 @@ module web_docker './app/web.bicep' = if (hostingModel == 'container') {
       AZURE_COSMOSDB_DATABASE: cosmosDBModule.outputs.cosmosOutput.cosmosDatabaseName
       AZURE_COSMOSDB_CONVERSATIONS_CONTAINER: cosmosDBModule.outputs.cosmosOutput.cosmosContainerName
       AZURE_COSMOSDB_ENABLE_FEEDBACK: true
-      CHAT_HISTORY_ENABLED: true
+      CHAT_HISTORY_ENABLED: chatHistoryEnabled
     }
   }
 }

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -19,6 +19,7 @@ param orchestrationStrategy = readEnvironmentVariable('ORCHESTRATION_STRATEGY', 
 param logLevel = readEnvironmentVariable('LOGLEVEL', 'INFO')
 param recognizedLanguages = readEnvironmentVariable('AZURE_SPEECH_RECOGNIZER_LANGUAGES', 'en-US,fr-FR,de-DE,it-IT')
 param conversationFlow = readEnvironmentVariable('CONVERSATION_FLOW', 'custom')
+param chatHistoryEnabled = readEnvironmentVariable('CHAT_HISTORY_ENABLED', 'true')
 
 //Azure Search
 param azureSearchFieldId = readEnvironmentVariable('AZURE_SEARCH_FIELDS_ID', 'id')

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "9975660614015683026"
+      "templateHash": "5381707032966472551"
     }
   },
   "parameters": {
@@ -610,6 +610,17 @@
       "defaultValue": "[format('aml-{0}', parameters('resourceToken'))]",
       "metadata": {
         "description": "Azure Machine Learning Name"
+      }
+    },
+    "chatHistoryEnabled": {
+      "type": "string",
+      "defaultValue": "true",
+      "allowedValues": [
+        "true",
+        "false"
+      ],
+      "metadata": {
+        "description": "Whether or not to enable chat history"
       }
     }
   },
@@ -2309,7 +2320,7 @@
               "AZURE_COSMOSDB_DATABASE": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosDatabaseName]",
               "AZURE_COSMOSDB_CONVERSATIONS_CONTAINER": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosContainerName]",
               "AZURE_COSMOSDB_ENABLE_FEEDBACK": true,
-              "CHAT_HISTORY_ENABLED": true
+              "CHAT_HISTORY_ENABLED": "[parameters('chatHistoryEnabled')]"
             }
           }
         },
@@ -3282,7 +3293,7 @@
               "AZURE_COSMOSDB_DATABASE": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosDatabaseName]",
               "AZURE_COSMOSDB_CONVERSATIONS_CONTAINER": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosContainerName]",
               "AZURE_COSMOSDB_ENABLE_FEEDBACK": true,
-              "CHAT_HISTORY_ENABLED": true
+              "CHAT_HISTORY_ENABLED": "[parameters('chatHistoryEnabled')]"
             }
           }
         },


### PR DESCRIPTION
## Purpose
This PR introduces an Chat History Enabled option to the template configuration, allowing users to enable or disable chat history.

[User Story 7269](https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/7269): [PSL] BE: [Bicep] Add enable chat history to the configuration template