### PR TITLE
Fix:Typo in Delete confirmation dialog box

### DIFF
--- a/code/frontend/src/pages/chat/ChatHistoryListItem.tsx
+++ b/code/frontend/src/pages/chat/ChatHistoryListItem.tsx
@@ -73,7 +73,7 @@ export const ChatHistoryListItemCell: React.FC<
     type: DialogType.close,
     title: "Are you sure you want to delete this item?",
     closeButtonAriaLabel: "Close",
-    subText: "The history of this chat session will permanently removed.",
+    subText: "The history of this chat session will be permanently removed.",
   };
 
   const modalProps = {


### PR DESCRIPTION


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

message updated to "The history of this chat session will be permanently removed."

![image](https://github.com/user-attachments/assets/6bc878a1-9e3a-488b-bb39-fa963f0a1951)
