### PR TITLE
fix: Fix for Enable Chat History Issue in Configuration and Cosmos DB Account Name Issue in Deployment Script

### DIFF
--- a/code/backend/batch/utilities/helpers/config/config_helper.py
+++ b/code/backend/batch/utilities/helpers/config/config_helper.py
@@ -57,7 +57,9 @@ class Config:
             if self.env_helper.AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION
             else None
         )
-        self.enable_chat_history = self.env_helper.CHAT_HISTORY_ENABLED
+        self.enable_chat_history = config.get(
+            "enable_chat_history", self.env_helper.CHAT_HISTORY_ENABLED
+        )
 
     def get_available_document_types(self) -> list[str]:
         document_types = {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -301,6 +301,9 @@ param recognizedLanguages string = 'en-US,fr-FR,de-DE,it-IT'
 @description('Azure Machine Learning Name')
 param azureMachineLearningName string = 'aml-${resourceToken}'
 
+@description('Azure Cosmos DB Account Name')
+param azureCosmosDBAccountName string = 'cosmos-${resourceToken}'
+
 @description('Whether or not to enable chat history')
 @allowed([
   'true'
@@ -326,8 +329,8 @@ resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
 module cosmosDBModule './core/database/cosmosdb.bicep' = {
   name: 'deploy_cosmos_db'
   params: {
-    solutionName: environmentName
-    solutionLocation: location
+    name: azureCosmosDBAccountName
+    location: location
   }
   scope: rg
 }
@@ -784,6 +787,7 @@ module adminweb './app/adminweb.bicep' = if (hostingModel == 'code') {
       FUNCTION_KEY: clientKey
       ORCHESTRATION_STRATEGY: orchestrationStrategy
       LOGLEVEL: logLevel
+      CHAT_HISTORY_ENABLED: chatHistoryEnabled
     }
   }
 }
@@ -864,6 +868,7 @@ module adminweb_docker './app/adminweb.bicep' = if (hostingModel == 'container')
       FUNCTION_KEY: clientKey
       ORCHESTRATION_STRATEGY: orchestrationStrategy
       LOGLEVEL: logLevel
+      CHAT_HISTORY_ENABLED: chatHistoryEnabled
     }
   }
 }

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "5381707032966472551"
+      "templateHash": "3804643920103148518"
     }
   },
   "parameters": {
@@ -612,6 +612,13 @@
         "description": "Azure Machine Learning Name"
       }
     },
+    "azureCosmosDBAccountName": {
+      "type": "string",
+      "defaultValue": "[format('cosmos-{0}', parameters('resourceToken'))]",
+      "metadata": {
+        "description": "Azure Cosmos DB Account Name"
+      }
+    },
     "chatHistoryEnabled": {
       "type": "string",
       "defaultValue": "true",
@@ -681,10 +688,10 @@
         },
         "mode": "Incremental",
         "parameters": {
-          "solutionName": {
-            "value": "[parameters('environmentName')]"
+          "name": {
+            "value": "[parameters('azureCosmosDBAccountName')]"
           },
-          "solutionLocation": {
+          "location": {
             "value": "[parameters('location')]"
           }
         },
@@ -695,24 +702,22 @@
             "_generator": {
               "name": "bicep",
               "version": "0.29.47.4906",
-              "templateHash": "4768626235519880181"
+              "templateHash": "4507438194893692755"
             }
           },
           "parameters": {
-            "solutionName": {
+            "name": {
               "type": "string",
-              "minLength": 3,
-              "maxLength": 15,
               "metadata": {
-                "description": "Solution Name"
+                "description": "Azure Cosmos DB Account Name"
               }
             },
-            "solutionLocation": {
+            "location": {
               "type": "string"
             },
             "accountName": {
               "type": "string",
-              "defaultValue": "[format('{0}-cosmos', parameters('solutionName'))]",
+              "defaultValue": "[parameters('name')]",
               "metadata": {
                 "description": "Name"
               }
@@ -778,7 +783,7 @@
               "apiVersion": "2022-08-15",
               "name": "[parameters('accountName')]",
               "kind": "[parameters('kind')]",
-              "location": "[parameters('solutionLocation')]",
+              "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
               "properties": {
                 "consistencyPolicy": {
@@ -786,7 +791,7 @@
                 },
                 "locations": [
                   {
-                    "locationName": "[parameters('solutionLocation')]",
+                    "locationName": "[parameters('location')]",
                     "failoverPriority": 0,
                     "isZoneRedundant": false
                   }
@@ -4259,7 +4264,8 @@
               "DOCUMENT_PROCESSING_QUEUE_NAME": "[variables('queueName')]",
               "FUNCTION_KEY": "[variables('clientKey')]",
               "ORCHESTRATION_STRATEGY": "[parameters('orchestrationStrategy')]",
-              "LOGLEVEL": "[parameters('logLevel')]"
+              "LOGLEVEL": "[parameters('logLevel')]",
+              "CHAT_HISTORY_ENABLED": "[parameters('chatHistoryEnabled')]"
             }
           }
         },
@@ -5210,7 +5216,8 @@
               "DOCUMENT_PROCESSING_QUEUE_NAME": "[variables('queueName')]",
               "FUNCTION_KEY": "[variables('clientKey')]",
               "ORCHESTRATION_STRATEGY": "[parameters('orchestrationStrategy')]",
-              "LOGLEVEL": "[parameters('logLevel')]"
+              "LOGLEVEL": "[parameters('logLevel')]",
+              "CHAT_HISTORY_ENABLED": "[parameters('chatHistoryEnabled')]"
             }
           }
         },


### PR DESCRIPTION
## Purpose
Fix for Enable Chat History Issue in Configuration and Cosmos DB Account Name Issue in Deployment Script.

Cosmos DB Account Name: 
<img width="935" alt="image" src="https://github.com/user-attachments/assets/8b3b06be-223f-4c25-9b69-afd565ebc8e9">

Enable Chat History : 
<img width="923" alt="image" src="https://github.com/user-attachments/assets/3c5b6bdc-4787-486b-9afa-f02b041bdcac">
<img width="470" alt="image" src="https://github.com/user-attachments/assets/b1020048-4be8-4146-9cd3-36ef15888501">

