### PR TITLE
Fix: Allow Same Conversation name as valid and stop error message

### DIFF
--- a/code/frontend/src/components/Answer/Answer.tsx
+++ b/code/frontend/src/components/Answer/Answer.tsx
@@ -317,11 +317,16 @@ export const Answer = ({
                   horizontal
                   horizontalAlign="start"
                   verticalAlign="center"
+                  tabIndex={0}
+                  onClick={handleChevronClick}
+                  role="button"
+                  onKeyDown={(e) =>
+                    e.key === " " || e.key === "Enter"
+                      ? handleChevronClick()
+                      : null
+                  }
                 >
-                  <Text
-                    className={styles.accordionTitle}
-                    onClick={toggleIsRefAccordionOpen}
-                  >
+                  <Text className={styles.accordionTitle}>
                     <span>
                       {parsedAnswer.citations.length > 1
                         ? parsedAnswer.citations.length + " references"
@@ -330,18 +335,10 @@ export const Answer = ({
                   </Text>
                   <FontIcon
                     className={styles.accordionIcon}
-                    onClick={handleChevronClick}
                     iconName={
                       chevronIsExpanded ? "ChevronDown" : "ChevronRight"
                     }
                     aria-hidden={false}
-                    role="button"
-                    onKeyDown={(e) =>
-                      e.key === " " || e.key === "Enter"
-                        ? handleChevronClick()
-                        : null
-                    }
-                    tabIndex={0}
                   />
                 </Stack>
               </Stack>

--- a/code/frontend/src/pages/chat/ChatHistoryListItem.tsx
+++ b/code/frontend/src/pages/chat/ChatHistoryListItem.tsx
@@ -21,7 +21,7 @@ import { useBoolean } from "@fluentui/react-hooks";
 
 import { historyRename, historyDelete } from "../../api";
 import { Conversation } from "../../api/models";
-
+import _ from 'lodash';
 import { GroupedChatHistory } from "./ChatHistoryList";
 
 import styles from "./ChatHistoryPanel.module.css";
@@ -129,15 +129,10 @@ export const ChatHistoryListItemCell: React.FC<
     if (errorRename || renameLoading) {
       return;
     }
-    if (editTitle == item.title) {
-      setErrorRename("Error: Enter a new title to proceed.");
-      setTimeout(() => {
-        setErrorRename(undefined);
-        setTextFieldFocused(true);
-        if (textFieldRef.current) {
-          textFieldRef.current.focus();
-        }
-      }, 5000);
+
+    if (_.trim(editTitle) === _.trim(item?.title)) {
+      setEdit(false);
+      setTextFieldFocused(false);
       return;
     }
     setRenameLoading(true);


### PR DESCRIPTION
Bug ID: https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/8386

Now no error message will be shown if user submits with same conversation name.

1. Fix: Allow Same Conversation name as valid and stop error message

2. Fix: Citation References button click only on arrow icon
Now both **4 references text and arrow Icon** area click works to view citations list and accessibility issue also fixed
![image](https://github.com/user-attachments/assets/61ef8283-ab0a-472c-9b7d-2e63baf7ea37)


- [ ] Yes
- [x] No
